### PR TITLE
Base url mapping

### DIFF
--- a/django_esidoc/middleware.py
+++ b/django_esidoc/middleware.py
@@ -36,6 +36,7 @@ class CASMiddleware:
             user = CASBackend.authenticate(request, uai_numbers=uai_numbers)
             if user:
                 login(request, user, backend="django_esidoc.backends.CASBackend")
+                request.esidoc_user = True
             else:
                 return HttpResponseRedirect(ESIDOC_INACTIVE_USER_REDIRECT)
 

--- a/django_esidoc/utils.py
+++ b/django_esidoc/utils.py
@@ -10,6 +10,14 @@ ENT_OCCITANIEAGR_BASE_URL = getattr(settings, "ENT_OCCITANIEAGR_BASE_URL", "")
 ENT_CORRELYCE_BASE_URL = getattr(settings, "ENT_CORRELYCE_BASE_URL", "")
 ENT_QUERY_STRING_TRIGGER = getattr(settings, "ENT_QUERY_STRING_TRIGGER", "sso_id")
 
+BASE_URLS = {
+    "ESIDOC": ENT_ESIDOC_BASE_URL,
+    "OCCITANIE": ENT_OCCITANIE_BASE_URL,
+    "OCCITANIEAGR": ENT_OCCITANIEAGR_BASE_URL,
+    "CORRELYCE": ENT_CORRELYCE_BASE_URL,
+    "HDF": ENT_HDF_BASE_URL,
+}
+
 
 def get_redirect_url(request, path=None):
     """Get redirect url for cas"""
@@ -28,23 +36,6 @@ def get_redirect_url(request, path=None):
     return url
 
 
-def _get_cas_base_url(uai_number, ent):
-    """Get the CAS base url format depending on the ENT"""
-
-    if ent == "ESIDOC":
-        url = ENT_ESIDOC_BASE_URL.format(uai_number)
-    elif ent == "OCCITANIE":
-        url = ENT_OCCITANIE_BASE_URL
-    elif ent == "OCCITANIEAGR":
-        url = ENT_OCCITANIEAGR_BASE_URL
-    elif ent == "CORRELYCE":
-        url = ENT_CORRELYCE_BASE_URL
-    else:
-        url = ENT_HDF_BASE_URL
-
-    return url
-
-
 def get_cas_client(request):
     """Create a CAS client"""
 
@@ -52,7 +43,7 @@ def get_cas_client(request):
     ent = request.session.get("ent")
     cas_version = 2
 
-    server_url = _get_cas_base_url(uai_number, ent)
+    server_url = BASE_URLS.get(ent, ENT_HDF_BASE_URL).format(uai_number)
 
     next_page = request.path
     service_url = get_redirect_url(request, next_page)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="django-esidoc",
-    version="1.0.0",
+    version="1.1.0",
     description="Handle login and ticket validation for french ent (Esidoc, HDF and Occitanie)",
     url="https://github.com/briefmnews/django-esidoc",
     author="Brief.me",

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -130,7 +130,8 @@ class TestCASMiddleware:
         mock_verification_response.assert_called_once()
 
     @pytest.mark.parametrize(
-        "uai_number, ent", [("9999999Q", "HDF"), ("9990075C", "ESIDOC")],
+        "uai_number, ent",
+        [("9999999Q", "HDF"), ("9990075C", "ESIDOC")],
     )
     def test_validate_ticket_parse_error(self, uai_number, ent, request_builder):
         # GIVEN


### PR DESCRIPTION
I think that a dictionary lookup is more pythonic and declarative than a series of ifs.

I have not changed the logic, but I am wondering why there is a fallback on ENT_HDF_BASE_URL. Wouldn't it be better to explicitly lookup for HDF and let the exception raise if there is no base URL for a given ent? 